### PR TITLE
Stability

### DIFF
--- a/src/Gobie/Gobie.UnitTests/Gobie.UnitTests.csproj
+++ b/src/Gobie/Gobie.UnitTests/Gobie.UnitTests.csproj
@@ -16,16 +16,16 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-		<PackageReference Include="NUnit" Version="3.13.2" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+		<PackageReference Include="NUnit" Version="3.13.3" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-		<PackageReference Include="coverlet.collector" Version="3.1.1">
+		<PackageReference Include="coverlet.collector" Version="3.1.2">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Verify.NUnit" Version="16.0.0" />
-		<PackageReference Include="Verify.SourceGenerators" Version="1.3.0" />
+		<PackageReference Include="Verify.NUnit" Version="16.7.0" />
+		<PackageReference Include="Verify.SourceGenerators" Version="1.4.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Gobie/Gobie/Gobie.csproj
+++ b/src/Gobie/Gobie/Gobie.csproj
@@ -23,8 +23,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" PrivateAssets="all" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Gobie/Gobie/Models/ClassIdentifier.cs
+++ b/src/Gobie/Gobie/Models/ClassIdentifier.cs
@@ -6,8 +6,8 @@ public readonly struct ClassIdentifier : IEquatable<ClassIdentifier>
 {
     public ClassIdentifier(string classNamespace, string className)
     {
-        NamespaceName = classNamespace ?? throw new ArgumentNullException(nameof(classNamespace));
-        ClassName = className ?? throw new ArgumentNullException(nameof(className));
+        NamespaceName = classNamespace ?? string.Empty;
+        ClassName = className ?? string.Empty;
     }
 
     public string NamespaceName { get; }

--- a/src/Gobie/Gobie/Models/CodeOutput.cs
+++ b/src/Gobie/Gobie/Models/CodeOutput.cs
@@ -4,8 +4,8 @@ public readonly struct CodeOutput
 {
     public CodeOutput(string hintName, string code)
     {
-        HintName = hintName ?? throw new ArgumentNullException(nameof(hintName));
-        Code = code ?? throw new ArgumentNullException(nameof(code));
+        HintName = hintName ?? string.Empty; //TODO is this ok?
+        Code = code ?? string.Empty;
     }
 
     public string HintName { get; }

--- a/src/Gobie/Gobie/Models/MemberTargetAndTemplateData.cs
+++ b/src/Gobie/Gobie/Models/MemberTargetAndTemplateData.cs
@@ -11,9 +11,9 @@ public class MemberTargetAndTemplateData
     public MemberTargetAndTemplateData(TemplateType templateType, string generatorName, ClassIdentifier targetClass, string code)
     {
         TemplateType = templateType;
-        GeneratorName = generatorName ?? throw new ArgumentNullException(nameof(generatorName));
+        GeneratorName = generatorName ?? string.Empty;
         TargetClass = targetClass;
-        Code = code ?? throw new ArgumentNullException(nameof(code));
+        Code = code ?? string.Empty;
     }
 
     public TemplateType TemplateType { get; }
@@ -32,8 +32,8 @@ public class AssemblyTargetAndTemplateData
 {
     public AssemblyTargetAndTemplateData(string globalGeneratorName, Mustache.TemplateDefinition globalTemplate)
     {
-        GlobalGeneratorName = globalGeneratorName ?? throw new ArgumentNullException(nameof(globalGeneratorName));
-        GlobalTemplate = globalTemplate ?? throw new ArgumentNullException(nameof(globalTemplate));
+        GlobalGeneratorName = globalGeneratorName ?? string.Empty;
+        GlobalTemplate = globalTemplate;
     }
 
     public string GlobalGeneratorName { get; }

--- a/src/Gobie/Gobie/Models/OptionalParameter.cs
+++ b/src/Gobie/Gobie/Models/OptionalParameter.cs
@@ -10,9 +10,9 @@ public class OptionalParameter
         // The type specified in a constant declaration shall be sbyte, byte, short, ushort, int,
         // uint, long, ulong, char, float, double, decimal, bool, string, an enum_type, or a reference_type.
 
-        name = name ?? throw new ArgumentNullException(nameof(name));
+        name = name ?? string.Empty;
 
-        CsharpTypeName = csharpTypeName ?? throw new ArgumentNullException(nameof(csharpTypeName));
+        CsharpTypeName = csharpTypeName ?? string.Empty;
 
         NamePascal = name[0].ToString().ToUpperInvariant() + name.Substring(1);
     }

--- a/src/Gobie/Gobie/Models/RequiredParameter.cs
+++ b/src/Gobie/Gobie/Models/RequiredParameter.cs
@@ -13,12 +13,12 @@ public class RequiredParameter
         // The type specified in a constant declaration shall be sbyte, byte, short, ushort, int,
         // uint, long, ulong, char, float, double, decimal, bool, string, an enum_type, or a reference_type.
 
-        name = name ?? throw new ArgumentNullException(nameof(name));
+        name = name ?? string.Empty;
 
         RequestedOrder = requestedOrder;
         RequestedOrderLocation = location;
         DeclaredOrder = declaredOrder;
-        CsharpTypeName = csharpTypeName ?? throw new ArgumentNullException(nameof(csharpTypeName));
+        CsharpTypeName = csharpTypeName ?? string.Empty;
 
         NamePascal = name[0].ToString().ToUpperInvariant() + name.Substring(1);
         NameCamel = name[0].ToString().ToLowerInvariant() + name.Substring(1);

--- a/src/Gobie/Gobie/Models/UserData/GlobalChildTemplateData.cs
+++ b/src/Gobie/Gobie/Models/UserData/GlobalChildTemplateData.cs
@@ -5,7 +5,7 @@
         public GlobalChildTemplateData(string templateName, Mustache.TemplateDefinition template)
         {
             GlobalTemplateName = templateName;
-            Template = template ?? throw new ArgumentNullException(nameof(template));
+            Template = template;
         }
 
         public string GlobalTemplateName { get; }

--- a/src/Gobie/Gobie/Models/UserData/GlobalTemplateData.cs
+++ b/src/Gobie/Gobie/Models/UserData/GlobalTemplateData.cs
@@ -5,8 +5,8 @@
         public GlobalTemplateData(string templateName, string fileName, Mustache.TemplateDefinition template)
         {
             TemplateName = templateName;
-            FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
-            Template = template ?? throw new ArgumentNullException(nameof(template));
+            FileName = fileName ?? string.Empty;
+            Template = template;
         }
 
         public string TemplateName { get; }

--- a/src/Gobie/Gobie/Models/UserData/UserFileTemplateData.cs
+++ b/src/Gobie/Gobie/Models/UserData/UserFileTemplateData.cs
@@ -4,8 +4,8 @@ public class UserFileTemplateData
 {
     public UserFileTemplateData(string fileName, Mustache.TemplateDefinition template)
     {
-        FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
-        Template = template ?? throw new ArgumentNullException(nameof(template));
+        FileName = fileName ?? string.Empty;
+        Template = template;
     }
 
     public string FileName { get; }

--- a/src/Gobie/Gobie/Workflows/CodeGeneration.cs
+++ b/src/Gobie/Gobie/Workflows/CodeGeneration.cs
@@ -17,12 +17,13 @@ public static class CodeGeneration
         IncrementalValueProvider<(ImmutableArray<MemberTargetAndTemplateData> Left,
                                   ImmutableArray<AssemblyTargetAndTemplateData> Right)> targets)
     {
-        return targets.Select(static (s, _) => OutputFiles(s.Left, s.Right));
+        return targets.Select(static (s, ct) => OutputFiles(s.Left, s.Right, ct));
     }
 
     private static ImmutableArray<CodeOutput> OutputFiles(
         ImmutableArray<MemberTargetAndTemplateData> memberTemplates,
-        ImmutableArray<AssemblyTargetAndTemplateData> assemblyTemplates)
+        ImmutableArray<AssemblyTargetAndTemplateData> assemblyTemplates,
+        CancellationToken ct)
     {
         var codeOut = ImmutableArray.CreateBuilder<CodeOutput>();
         var globalTemplates = new Dictionary<string, StringBuilder>();
@@ -31,6 +32,8 @@ public static class CodeGeneration
 
         foreach (var group in fileGroups)
         {
+            ct.ThrowIfCancellationRequested();
+
             if (group.Key.TemplateType == TemplateType.Complete)
             {
                 var sb = new StringBuilder();
@@ -78,6 +81,8 @@ public static class CodeGeneration
 
         foreach (var assemblyTemplate in assemblyTemplates)
         {
+            ct.ThrowIfCancellationRequested();
+
             var hintName = $"{assemblyTemplate.GlobalGeneratorName}.g.cs";
             var renderData = ImmutableDictionary.CreateBuilder<string, Mustache.RenderData>();
 


### PR DESCRIPTION
Newest vs preview still prone to crashing. Because of https://github.com/dotnet/roslyn/issues/54098 just being resolved, along with some related issues. The generator appearing to crash all the time might not be entirely from gobie. At least as long as we aren't finding instances that crash the `DoesNotCrash` tests